### PR TITLE
fix(.github/workflows/json.yml): bugfix leftover in dir/file style

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -75,7 +75,7 @@ jobs:
           git checkout -B deployment origin/deployment
 
           # Stage changes
-          git add ${{ env.JSON_DIR }}/${{ env.JSON_FILE }}.json
+          git add ${{ env.JSON_DIR }}/${{ env.JSON_FILE }}
 
           # Commit only if there are changes
           git diff --cached --quiet || git commit -m "Format JSON files with Prettier."


### PR DESCRIPTION
Fixed issue with `.json` extension

```
env:
  JSON_DIR: .
  JSON_FILE: knowledgebase.json
```

```
git add ${{ env.JSON_DIR }}/${{ env.JSON_FILE }}.json  # wrong
git add ${{ env.JSON_DIR }}/${{ env.JSON_FILE }}          # correct
```